### PR TITLE
Update to GNOME 45 and automate updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.json]
+indent_size = 4
+indent_style = space

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Flatpak for GStreamer Debug Viewer
+
+Viewer for GStreamer debug log files. For more information, please [visit the project website](https://gstreamer.freedesktop.org) or [view the source code](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-devtools/debug-viewer)
+
+## Usage notes
+A log can be produced using the `GST_DEBUG_FILE` environment variable:
+```
+GST_DEBUG_FILE=test.log GST_DEBUG=DEBUG gst-play-1.0 https://archive.org/download/BigBuckBunny_124/Content/big_buck_bunny_720p_surround.ogv
+```
+
+The log file can be opened via the command line using the flatpak option [`--file-forwarding`](https://docs.flatpak.org/en/latest/flatpak-command-reference.html#idm45858572528784):
+```
+flatpak run --file-forwarding org.freedesktop.GstDebugViewer @@ ./test.log @@
+```

--- a/chooser_native.patch
+++ b/chooser_native.patch
@@ -1,0 +1,17 @@
+diff --git a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py
+index 43ed9c0810..43d2dc2fc4 100644
+--- a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py
++++ b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py
+@@ -569,10 +569,8 @@ class Window (object):
+     @action
+     def handle_open_file_action_activate(self, action):
+ 
+-        dialog = Gtk.FileChooserDialog(None, self.gtk_window,
+-                                       Gtk.FileChooserAction.OPEN,
+-                                       (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL,
+-                                        Gtk.STOCK_OPEN, Gtk.ResponseType.ACCEPT,))
++        dialog = Gtk.FileChooserNative.new(None, self.gtk_window,
++                                       Gtk.FileChooserAction.OPEN, None, None)
+         response = dialog.run()
+         dialog.hide()
+         if response == Gtk.ResponseType.ACCEPT:

--- a/find_bar_none.patch
+++ b/find_bar_none.patch
@@ -1,0 +1,80 @@
+diff --git a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py
+index 43ed9c0810..db0ef30536 100644
+--- a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py
++++ b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/GUI/window.py
+@@ -532,7 +532,10 @@ class Window (object):
+         view = self.log_view
+         model = view.get_model()
+ 
+-        start_path, end_path = view.get_visible_range()
++        visible_range = view.get_visible_range()
++        if visible_range is None:
++            return
++        start_path, end_path = visible_range
+         start_index, end_index = start_path[0], end_path[0]
+ 
+         for line_index in range(start_index, end_index + 1):
+diff --git a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Plugins/FindBar.py b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Plugins/FindBar.py
+index 151773fceb..76ec0a65d5 100644
+--- a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Plugins/FindBar.py
++++ b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Plugins/FindBar.py
+@@ -245,7 +245,10 @@ class FindBarFeature (FeatureBase):
+ 
+         path = Gtk.TreePath((line_index,))
+ 
+-        start_path, end_path = view.get_visible_range()
++        visible_range = view.get_visible_range()
++        if visible_range is None:
++            return
++        start_path, end_path = visible_range
+ 
+         if path >= start_path and path <= end_path:
+             self.logger.debug(
+@@ -330,7 +333,10 @@ class FindBarFeature (FeatureBase):
+         self.scroll_view_to_line(self.prev_match)
+         self.prev_match = None
+ 
+-        start_path = self.log_view.get_visible_range()[0]
++        visible_range = self.log_view.get_visible_range()
++        if visible_range is None:
++            return
++        start_path = visible_range[0]
+         new_position = start_path[0] - 1
+         self.start_search_operation(start_position=new_position,
+                                     forward=False)
+@@ -346,7 +352,10 @@ class FindBarFeature (FeatureBase):
+         self.scroll_view_to_line(self.next_match)
+         self.next_match = None
+ 
+-        end_path = self.log_view.get_visible_range()[1]
++        visible_range = self.log_view.get_visible_range()
++        if visible_range is None:
++            return
++        end_path = visible_range[1]
+         new_position = end_path[0] + 1
+         self.start_search_operation(start_position=new_position,
+                                     forward=True)
+@@ -354,7 +363,10 @@ class FindBarFeature (FeatureBase):
+ 
+         # model = self.log_view.get_model ()
+ 
+-        # start_path, end_path = self.log_view.get_visible_range ()
++        # visible_range = self.log_view.get_visible_range()
++        # if visible_range is None:
++        #     return
++        # start_path, end_path = visible_range
+         # start_index, end_index = start_path[0], end_path[0]
+ 
+         # for line_index in self.matches:
+@@ -392,7 +404,10 @@ class FindBarFeature (FeatureBase):
+             self.update_sensitivity()
+             self.scroll_match = True
+ 
+-            start_path = self.log_view.get_visible_range()[0]
++            visible_range = self.log_view.get_visible_range()
++            if visible_range is None:
++                return
++            start_path = visible_range[0]
+             self.start_search_operation(
+                 search_text, start_position=start_path[0])
+             self.bar.status_searching()

--- a/gettext-py310-mr5027.patch
+++ b/gettext-py310-mr5027.patch
@@ -1,0 +1,28 @@
+From 98217f1892ea2472e1c0456bf4c407daf7e28ca2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Olivier=20Cr=C3=AAte?= <olivier.crete@collabora.com>
+Date: Wed, 12 Jul 2023 14:57:28 -0600
+Subject: [PATCH] debug-viewer: Remove unnecessary call to
+ gettext.bind_textdomain_codeset()
+
+It has been deprecated in Python 3.8 and removed in 3.10
+
+Part-of: <https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5027>
+---
+ .../gst-devtools/debug-viewer/GstDebugViewer/Common/Main.py      | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Common/Main.py b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Common/Main.py
+index e7f8552ce84..c57f5fa6fed 100644
+--- a/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Common/Main.py
++++ b/subprojects/gst-devtools/debug-viewer/GstDebugViewer/Common/Main.py
+@@ -314,7 +314,6 @@ def _init_locale(gettext_domain=None):
+         else:
+             gettext.bindtextdomain(gettext_domain, Paths.locale_dir)
+             gettext.textdomain(gettext_domain)
+-            gettext.bind_textdomain_codeset(gettext_domain, "UTF-8")
+ 
+ 
+ def _init_logging(level):
+-- 
+GitLab
+

--- a/org.freedesktop.GstDebugViewer.json
+++ b/org.freedesktop.GstDebugViewer.json
@@ -1,28 +1,21 @@
 {
-    "app-id" : "org.freedesktop.GstDebugViewer",
-    "branch" : "stable",
-    "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
-    "sdk" : "org.gnome.Sdk",
-    "command" : "gst-debug-viewer",
-    "rename-icon" : "gst-debug-viewer",
-    "copy-icon" : true,
-    "finish-args" : [
-        "--socket=x11",
+    "app-id": "org.freedesktop.GstDebugViewer",
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "45",
+    "sdk": "org.gnome.Sdk",
+    "command": "gst-debug-viewer",
+    "rename-icon": "gst-debug-viewer",
+    "copy-icon": true,
+    "finish-args": [
+        "--device=dri",
         "--share=ipc",
-        "--socket=wayland",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
-        "--talk-name=org.freedesktop.Notifications",
-        "--filesystem=host",
-        "--device=dri"
+        "--socket=fallback-x11",
+        "--socket=wayland"
     ],
-    "modules" : [
+    "modules": [
         {
-            "name" : "gst-debug-viewer",
-            "buildsystem" : "meson",
+            "name": "gst-debug-viewer",
+            "buildsystem": "meson",
             "subdir": "subprojects/gst-devtools",
             "config-opts": [
                 "-Dvalidate=disabled",
@@ -30,13 +23,31 @@
                 "-Dtests=disabled",
                 "-Ddebug_viewer=enabled"
             ],
-            "sources" : [
+            "sources": [
                 {
-                    "type" : "git",
-  		              "disable-submodules": true,
-                    "tag" : "1.20.5",
-     		            "commit": "f7806a854aad960eae3288db4a67a574f92428fe",
-                    "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer.git"
+                    "type": "git",
+                    "disable-submodules": true,
+                    "tag": "1.22.6",
+                    "commit": "ddb4fbe43149b157efb52b6472313f48308c1dbc",
+                    "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer.git",
+                    "x-checker-data": {
+                        "type": "anitya",
+                        "project-id": 1263,
+                        "stable-only": true,
+                        "tag-template": "$version"
+                    }
+                },
+                {
+                    "type": "patch",
+                    "path": "gettext-py310-mr5027.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "chooser_native.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "find_bar_none.patch"
                 }
             ]
         }

--- a/org.freedesktop.GstDebugViewer.json
+++ b/org.freedesktop.GstDebugViewer.json
@@ -10,7 +10,8 @@
         "--device=dri",
         "--share=ipc",
         "--socket=fallback-x11",
-        "--socket=wayland"
+        "--socket=wayland",
+        "--filesystem=home:ro"
     ],
     "modules": [
         {


### PR DESCRIPTION
* Update to Gnome SDK 45
* Add a `.editorconfig` to avoid mixing tabs and spaces.
* Add `x-checker-data` field to track latest stable gstreamer branch.
* Lint with `flatpak run org.flathub.flatpak-external-data-checker --edit-only ./org.freedesktop.GstDebugViewer.json`
* Add fix removing deprecated gettext function [gstreamer!5027](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/5027)
* Switch from `--socket=x11` to `--socket=fallback-x11`
* Added patch to use GtkFileChooserNative for portal support
* Removed host filesystem access
* Added patch to fix FindBar crashes
* Removed access to dconf
* Removed notification access
* Removed `"branch": "stable"` field
* Add `README.md`

This is a lot of permission changes and I'm not familiar enough with the debug viewer to know whether any of these changes will cause inconvenience.
I believe it's a very simple app that only reads one file at a time, has very few settings to save and doesn't use notifications.